### PR TITLE
Fix critical underscore alert

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3365,9 +3365,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "dev": true
     },
     "underscore.string": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node-sass": "~4.5.0",
     "rtlcss": "^2.4.0",
     "susy": "~2.2.5",
-    "underscore": "~1.9.1"
+    "underscore": "^1.13.7"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
## Summary
- Bumps underscore from 1.9.1 to 1.13.7.
- Refreshes the npm v1 shrinkwrap entry while preserving the existing shrinkwrap format.

## Testing
- Verified package.json and npm-shrinkwrap.json resolve underscore 1.13.7
- JavaScript syntax checks for build tools
- git diff --check

## Notes
- A full npm 6 audit still reports critical findings in the old Grunt/node-sass dependency stack. Clearing those requires a broader theme tooling migration or archive decision, so this PR stays scoped to the direct GitHub critical alert.